### PR TITLE
feat: add `accents` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ zig build
 ## Usage
 
 ```sh
-xtxf -p -m decimal -c red -s crypto
+xtxf -a -m decimal -c red -s crypto
 ```

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -116,6 +116,16 @@ pub const setup_cmd: CommandT = .{
             .val = ValueT.ofType(Mode, .{ .name = "mode_val", .default_val = Mode.binary, .alias_child_type = "string" }),
         },
         .{
+            .name = "accents",
+            .description = "Enable symbol accentuations.",
+            .short_name = 'a',
+            .long_name = "accents",
+            .val = ValueT.ofType(bool, .{
+                .name = "accents_flag",
+                .default_val = false,
+            }),
+        },
+        .{
             .name = "pulse",
             .description = "Enable pulse blocks.",
             .short_name = 'p',

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -84,7 +84,7 @@ pub const setup_cmd: CommandT = .{
     .name = "xtxf",
     .description = "2D matrix screensaver.",
     .examples = &.{
-        "xtxf -p -m decimal -c red -s crypto",
+        "xtxf -a -m decimal -c red -s crypto",
     },
     .sub_cmds_mandatory = false,
     .sub_cmds = &.{

--- a/src/main.zig
+++ b/src/main.zig
@@ -70,6 +70,7 @@ const Core = struct {
     debug: bool = false,
     active: bool = false,
     rendering: bool = false,
+    accents: bool = false,
     pulse: bool = false,
     color: Color = Color.default,
     bg: u32 = tb.TB_DEFAULT,
@@ -101,8 +102,8 @@ const Core = struct {
             }
         }
 
-        self.width = if (self.debug) 20 else @intCast(width);
-        self.height = if (self.debug) 20 else @intCast(height);
+        self.width = if (self.debug) 12 else @intCast(width);
+        self.height = if (self.debug) 10 else @intCast(height);
     }
 
     fn updateWidthSec(self: *Core, adv: u32) !void {
@@ -488,7 +489,6 @@ fn printCells(
 }
 
 fn newChar(core: *Core, mode: Mode, rand: std.rand.Random) Char {
-    const bold = rand.boolean();
     const rand_int = switch (mode) {
         .binary => rand.int(u1),
         .decimal => rand.uintLessThan(u4, 10),
@@ -508,8 +508,17 @@ fn newChar(core: *Core, mode: Mode, rand: std.rand.Random) Char {
         }
     }
 
-    if (bold) {
-        color = color | tb.TB_BOLD;
+    if (core.accents) {
+        const bold = rand.boolean();
+        const dim = rand.boolean();
+
+        if (bold) {
+            color = color | tb.TB_BOLD;
+        }
+
+        if (dim) {
+            color = color | tb.TB_DIM;
+        }
     }
 
     return Char{ .i = rand_int, .b = bg, .c = color };
@@ -622,6 +631,10 @@ pub fn main() !void {
 
     if (opts.get("speed")) |speed| {
         handler.speed = try speed.val.getAs(Speed);
+    }
+
+    if (opts.get("accents")) |accents| {
+        core.accents = try accents.val.getAs(bool);
     }
 
     if (opts.get("pulse")) |pulse| {

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const streams = @import("streams.zig");
 
 const build_options = @import("build_options");
 const exe_path = build_options.exe_path;
@@ -41,7 +42,7 @@ test "default" {
         std.testing.allocator.free(proc.err);
     }
 
-    try std.testing.expectStringEndsWith(proc.err, default_run);
+    try std.testing.expectStringEndsWith(proc.err, streams.default);
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
 
@@ -53,7 +54,7 @@ test "speed" {
         std.testing.allocator.free(proc.err);
     }
 
-    try std.testing.expectStringEndsWith(proc.err, default_run);
+    try std.testing.expectStringEndsWith(proc.err, streams.default);
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
 
@@ -65,7 +66,7 @@ test "mode: decimal" {
         std.testing.allocator.free(proc.err);
     }
 
-    try std.testing.expectStringEndsWith(proc.err, decimal_run);
+    try std.testing.expectStringEndsWith(proc.err, streams.decimal);
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
 
@@ -77,7 +78,7 @@ test "mode: hexadecimal" {
         std.testing.allocator.free(proc.err);
     }
 
-    try std.testing.expectStringEndsWith(proc.err, hexadecimal_run);
+    try std.testing.expectStringEndsWith(proc.err, streams.hexadecimal);
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
 
@@ -89,7 +90,7 @@ test "mode: textual" {
         std.testing.allocator.free(proc.err);
     }
 
-    try std.testing.expectStringEndsWith(proc.err, textual_run);
+    try std.testing.expectStringEndsWith(proc.err, streams.textual);
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
 
@@ -101,7 +102,7 @@ test "color: red" {
         std.testing.allocator.free(proc.err);
     }
 
-    try std.testing.expectStringEndsWith(proc.err, red_run);
+    try std.testing.expectStringEndsWith(proc.err, streams.red);
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
 
@@ -113,7 +114,7 @@ test "color: green" {
         std.testing.allocator.free(proc.err);
     }
 
-    try std.testing.expectStringEndsWith(proc.err, green_run);
+    try std.testing.expectStringEndsWith(proc.err, streams.green);
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
 
@@ -124,7 +125,7 @@ test "color: blue" {
         std.testing.allocator.free(proc.out);
         std.testing.allocator.free(proc.err);
     }
-    try std.testing.expectStringEndsWith(proc.err, blue_run);
+    try std.testing.expectStringEndsWith(proc.err, streams.blue);
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
 
@@ -136,7 +137,7 @@ test "color: yellow" {
         std.testing.allocator.free(proc.err);
     }
 
-    try std.testing.expectStringEndsWith(proc.err, yellow_run);
+    try std.testing.expectStringEndsWith(proc.err, streams.yellow);
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
 
@@ -148,7 +149,7 @@ test "color: magenta" {
         std.testing.allocator.free(proc.err);
     }
 
-    try std.testing.expectStringEndsWith(proc.err, magenta_run);
+    try std.testing.expectStringEndsWith(proc.err, streams.magenta);
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
 
@@ -160,7 +161,7 @@ test "style: columns" {
         std.testing.allocator.free(proc.err);
     }
 
-    try std.testing.expectStringEndsWith(proc.err, columns_run);
+    try std.testing.expectStringEndsWith(proc.err, streams.columns);
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
 
@@ -172,7 +173,7 @@ test "style: crypto" {
         std.testing.allocator.free(proc.err);
     }
 
-    try std.testing.expectStringEndsWith(proc.err, crypto_run);
+    try std.testing.expectStringEndsWith(proc.err, streams.crypto);
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
 
@@ -184,7 +185,7 @@ test "style: grid" {
         std.testing.allocator.free(proc.err);
     }
 
-    try std.testing.expectStringEndsWith(proc.err, grid_run);
+    try std.testing.expectStringEndsWith(proc.err, streams.grid);
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
 
@@ -196,7 +197,7 @@ test "style: blocks" {
         std.testing.allocator.free(proc.err);
     }
 
-    try std.testing.expectStringEndsWith(proc.err, blocks_run);
+    try std.testing.expectStringEndsWith(proc.err, streams.blocks);
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
 
@@ -208,187 +209,6 @@ test "style: rain" {
         std.testing.allocator.free(proc.err);
     }
 
-    try std.testing.expectStringEndsWith(proc.err, rain_run);
+    try std.testing.expectStringEndsWith(proc.err, streams.rain);
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
-
-const default_run =
-    \\info(xtxf): 0: 19x0 0/0
-    \\info(xtxf): 0: 19x1 0/0
-    \\info(xtxf): 0: 19x2 256/0
-    \\info(xtxf): 0: 19x3 256/0
-    \\info(xtxf): 0: 19x4 256/0
-    \\info(xtxf): 1: 19x5 256/0
-    \\info(xtxf): 0: 19x6 256/0
-    \\info(xtxf): 1: 19x7 0/0
-    \\info(xtxf): 0: 19x8 256/0
-    \\info(xtxf): 0: 19x9 0/0
-    \\info(xtxf): 1: 19x10 256/0
-    \\info(xtxf): 0: 19x11 256/0
-    \\info(xtxf): 1: 19x12 0/0
-    \\info(xtxf): 1: 19x13 256/0
-    \\info(xtxf): 1: 19x14 0/0
-    \\info(xtxf): 1: 19x15 0/0
-    \\info(xtxf): 1: 19x16 0/0
-    \\info(xtxf): 0: 19x17 0/0
-    \\info(xtxf): 1: 19x18 0/0
-    \\info(xtxf): 1: 19x19 0/0
-    \\info(xtxf): Exiting...
-    \\
-;
-
-const decimal_run =
-    \\info(xtxf): 9: 19x10 0/0
-    \\info(xtxf): 8: 19x11 0/0
-    \\info(xtxf): 2: 19x12 256/0
-    \\info(xtxf): 2: 19x13 256/0
-    \\info(xtxf): 9: 19x14 256/0
-    \\info(xtxf): 6: 19x15 0/0
-    \\info(xtxf): 6: 19x16 0/0
-    \\info(xtxf): 5: 19x17 256/0
-    \\info(xtxf): 0: 19x18 256/0
-    \\info(xtxf): 0: 19x19 0/0
-    \\info(xtxf): Exiting...
-    \\
-;
-
-const hexadecimal_run =
-    \\info(xtxf): F: 19x12 0/0
-    \\info(xtxf): D: 19x13 256/0
-    \\info(xtxf): 3: 19x14 0/0
-    \\info(xtxf): 7: 19x15 0/0
-    \\info(xtxf): D: 19x16 0/0
-    \\info(xtxf): 4: 19x17 0/0
-    \\info(xtxf): 3: 19x18 0/0
-    \\info(xtxf): 9: 19x19 0/0
-    \\info(xtxf): Exiting...
-    \\
-;
-
-const textual_run =
-    \\info(xtxf): +: 19x12 0/0
-    \\info(xtxf): -: 19x13 0/0
-    \\info(xtxf): ｹ: 19x14 0/0
-    \\info(xtxf): ﾏ: 19x15 256/0
-    \\info(xtxf): V: 19x16 0/0
-    \\info(xtxf): ﾅ: 19x17 0/0
-    \\info(xtxf): ﾄ: 19x18 0/0
-    \\info(xtxf): ｢: 19x19 0/0
-    \\info(xtxf): Exiting...
-    \\
-;
-
-const red_run =
-    \\info(xtxf): 1: 19x13 258/0
-    \\info(xtxf): 1: 19x14 2/0
-    \\info(xtxf): 1: 19x15 2/0
-    \\info(xtxf): 1: 19x16 2/0
-    \\info(xtxf): 0: 19x17 2/0
-    \\info(xtxf): 1: 19x18 2/0
-    \\info(xtxf): 1: 19x19 2/0
-    \\info(xtxf): Exiting...
-    \\
-;
-
-const green_run =
-    \\info(xtxf): 1: 19x13 259/0
-    \\info(xtxf): 1: 19x14 3/0
-    \\info(xtxf): 1: 19x15 3/0
-    \\info(xtxf): 1: 19x16 3/0
-    \\info(xtxf): 0: 19x17 3/0
-    \\info(xtxf): 1: 19x18 3/0
-    \\info(xtxf): 1: 19x19 3/0
-    \\info(xtxf): Exiting...
-    \\
-;
-
-const blue_run =
-    \\info(xtxf): 1: 19x13 261/0
-    \\info(xtxf): 1: 19x14 5/0
-    \\info(xtxf): 1: 19x15 5/0
-    \\info(xtxf): 1: 19x16 5/0
-    \\info(xtxf): 0: 19x17 5/0
-    \\info(xtxf): 1: 19x18 5/0
-    \\info(xtxf): 1: 19x19 5/0
-    \\info(xtxf): Exiting...
-    \\
-;
-
-const yellow_run =
-    \\info(xtxf): 1: 19x13 260/0
-    \\info(xtxf): 1: 19x14 4/0
-    \\info(xtxf): 1: 19x15 4/0
-    \\info(xtxf): 1: 19x16 4/0
-    \\info(xtxf): 0: 19x17 4/0
-    \\info(xtxf): 1: 19x18 4/0
-    \\info(xtxf): 1: 19x19 4/0
-    \\info(xtxf): Exiting...
-    \\
-;
-
-const magenta_run =
-    \\info(xtxf): 1: 19x13 262/0
-    \\info(xtxf): 1: 19x14 6/0
-    \\info(xtxf): 1: 19x15 6/0
-    \\info(xtxf): 1: 19x16 6/0
-    \\info(xtxf): 0: 19x17 6/0
-    \\info(xtxf): 1: 19x18 6/0
-    \\info(xtxf): 1: 19x19 6/0
-    \\info(xtxf): Exiting...
-    \\
-;
-
-const columns_run =
-    \\info(xtxf): 6: 19x14 0/0
-    \\info(xtxf): 4: 19x15 0/0
-    \\info(xtxf): 3: 19x16 256/0
-    \\info(xtxf): 4: 19x17 256/0
-    \\info(xtxf): 2: 19x18 0/0
-    \\info(xtxf): 3: 19x19 0/0
-    \\info(xtxf): Exiting...
-    \\
-;
-
-const crypto_run =
-    \\info(xtxf): 1: 19x11 256/0
-    \\info(xtxf): 1: 19x13 0/0
-    \\info(xtxf): 3: 19x14 256/0
-    \\info(xtxf): E: 19x16 0/0
-    \\info(xtxf): 9: 19x17 0/0
-    \\info(xtxf): 8: 19x19 0/0
-    \\info(xtxf): Exiting...
-    \\
-;
-
-const grid_run =
-    \\info(xtxf): 0: 19x9 256/0
-    \\info(xtxf): 1: 19x11 0/0
-    \\info(xtxf): 0: 19x13 0/0
-    \\info(xtxf): 0: 19x15 0/0
-    \\info(xtxf): 0: 19x17 256/0
-    \\info(xtxf): 0: 19x19 0/0
-    \\info(xtxf): Exiting...
-    \\
-;
-
-const blocks_run =
-    \\info(xtxf): 1: 19x13 0/0
-    \\info(xtxf): 2: 19x14 0/0
-    \\info(xtxf): 7: 19x15 0/0
-    \\info(xtxf): 4: 19x16 256/0
-    \\info(xtxf): 5: 19x17 0/0
-    \\info(xtxf): 4: 19x19 0/0
-    \\info(xtxf): Exiting...
-    \\
-;
-
-const rain_run =
-    \\info(xtxf): ﾄ: 19x14 0/0
-    \\info(xtxf): ｾ: 19x15 0/0
-    \\info(xtxf): ｰ: 19x16 256/0
-    \\info(xtxf): ﾆ: 19x17 0/0
-    \\info(xtxf): #: 19x18 0/0
-    \\info(xtxf): 6: 19x19 0/0
-    \\info(xtxf): Exiting...
-    \\
-;

--- a/test/cli.zig
+++ b/test/cli.zig
@@ -46,6 +46,18 @@ test "default" {
     try std.testing.expectEqual(proc.term.Exited, 0);
 }
 
+test "accents" {
+    const argv = [4][]const u8{ exe_path, if (live) "--time=1" else "--debug", "-s=default", "--accents" };
+    const proc = try runner(argv);
+    defer {
+        std.testing.allocator.free(proc.out);
+        std.testing.allocator.free(proc.err);
+    }
+
+    try std.testing.expectStringEndsWith(proc.err, streams.accents);
+    try std.testing.expectEqual(proc.term.Exited, 0);
+}
+
 test "speed" {
     const argv = [4][]const u8{ exe_path, if (live) "--time=1" else "--debug", "-s=default", "--speed=slow" };
     const proc = try runner(argv);

--- a/test/streams.zig
+++ b/test/streams.zig
@@ -1,180 +1,246 @@
 pub const default =
-    \\info(xtxf): 0: 19x0 0/0
-    \\info(xtxf): 0: 19x1 0/0
-    \\info(xtxf): 0: 19x2 256/0
-    \\info(xtxf): 0: 19x3 256/0
-    \\info(xtxf): 0: 19x4 256/0
-    \\info(xtxf): 1: 19x5 256/0
-    \\info(xtxf): 0: 19x6 256/0
-    \\info(xtxf): 1: 19x7 0/0
-    \\info(xtxf): 0: 19x8 256/0
-    \\info(xtxf): 0: 19x9 0/0
-    \\info(xtxf): 1: 19x10 256/0
-    \\info(xtxf): 0: 19x11 256/0
-    \\info(xtxf): 1: 19x12 0/0
-    \\info(xtxf): 1: 19x13 256/0
-    \\info(xtxf): 1: 19x14 0/0
-    \\info(xtxf): 1: 19x15 0/0
-    \\info(xtxf): 1: 19x16 0/0
-    \\info(xtxf): 0: 19x17 0/0
-    \\info(xtxf): 1: 19x18 0/0
-    \\info(xtxf): 1: 19x19 0/0
+    \\info(xtxf): 1: 10x9 0/0
+    \\info(xtxf): 1: 11x0 0/0
+    \\info(xtxf): 0: 11x1 0/0
+    \\info(xtxf): 0: 11x2 0/0
+    \\info(xtxf): 0: 11x3 0/0
+    \\info(xtxf): 1: 11x4 0/0
+    \\info(xtxf): 0: 11x5 0/0
+    \\info(xtxf): 0: 11x6 0/0
+    \\info(xtxf): 0: 11x7 0/0
+    \\info(xtxf): 1: 11x8 0/0
+    \\info(xtxf): 0: 11x9 0/0
+    \\info(xtxf): Exiting...
+    \\
+;
+
+pub const accents =
+    \\info(xtxf): 0: 9x7 32768/0
+    \\info(xtxf): 0: 9x8 32768/0
+    \\info(xtxf): 0: 9x9 0/0
+    \\info(xtxf): 0: 10x0 256/0
+    \\info(xtxf): 0: 10x1 256/0
+    \\info(xtxf): 0: 10x2 32768/0
+    \\info(xtxf): 1: 10x3 33024/0
+    \\info(xtxf): 1: 10x4 32768/0
+    \\info(xtxf): 0: 10x5 256/0
+    \\info(xtxf): 1: 10x6 32768/0
+    \\info(xtxf): 1: 10x7 32768/0
+    \\info(xtxf): 0: 10x8 33024/0
+    \\info(xtxf): 0: 10x9 32768/0
+    \\info(xtxf): 0: 11x0 0/0
+    \\info(xtxf): 0: 11x1 33024/0
+    \\info(xtxf): 0: 11x2 32768/0
+    \\info(xtxf): 1: 11x3 33024/0
+    \\info(xtxf): 1: 11x4 33024/0
+    \\info(xtxf): 1: 11x5 33024/0
+    \\info(xtxf): 1: 11x6 32768/0
+    \\info(xtxf): 0: 11x7 32768/0
+    \\info(xtxf): 1: 11x8 256/0
+    \\info(xtxf): 1: 11x9 32768/0
     \\info(xtxf): Exiting...
     \\
 ;
 
 pub const decimal =
-    \\info(xtxf): 9: 19x10 0/0
-    \\info(xtxf): 8: 19x11 0/0
-    \\info(xtxf): 2: 19x12 256/0
-    \\info(xtxf): 2: 19x13 256/0
-    \\info(xtxf): 9: 19x14 256/0
-    \\info(xtxf): 6: 19x15 0/0
-    \\info(xtxf): 6: 19x16 0/0
-    \\info(xtxf): 5: 19x17 256/0
-    \\info(xtxf): 0: 19x18 256/0
-    \\info(xtxf): 0: 19x19 0/0
+    \\info(xtxf): 2: 10x9 0/0
+    \\info(xtxf): 4: 11x0 0/0
+    \\info(xtxf): 2: 11x1 0/0
+    \\info(xtxf): 3: 11x2 0/0
+    \\info(xtxf): 1: 11x3 0/0
+    \\info(xtxf): 0: 11x4 0/0
+    \\info(xtxf): 7: 11x5 0/0
+    \\info(xtxf): 6: 11x6 0/0
+    \\info(xtxf): 8: 11x7 0/0
+    \\info(xtxf): 8: 11x8 0/0
+    \\info(xtxf): 6: 11x9 0/0
     \\info(xtxf): Exiting...
     \\
 ;
 
 pub const hexadecimal =
-    \\info(xtxf): F: 19x12 0/0
-    \\info(xtxf): D: 19x13 256/0
-    \\info(xtxf): 3: 19x14 0/0
-    \\info(xtxf): 7: 19x15 0/0
-    \\info(xtxf): D: 19x16 0/0
-    \\info(xtxf): 4: 19x17 0/0
-    \\info(xtxf): 3: 19x18 0/0
-    \\info(xtxf): 9: 19x19 0/0
+    \\info(xtxf): 7: 10x9 0/0
+    \\info(xtxf): 9: 11x0 0/0
+    \\info(xtxf): 4: 11x1 0/0
+    \\info(xtxf): 6: 11x2 0/0
+    \\info(xtxf): 8: 11x3 0/0
+    \\info(xtxf): F: 11x4 0/0
+    \\info(xtxf): 0: 11x5 0/0
+    \\info(xtxf): C: 11x6 0/0
+    \\info(xtxf): 2: 11x7 0/0
+    \\info(xtxf): D: 11x8 0/0
+    \\info(xtxf): 8: 11x9 0/0
     \\info(xtxf): Exiting...
     \\
 ;
 
 pub const textual =
-    \\info(xtxf): +: 19x12 0/0
-    \\info(xtxf): -: 19x13 0/0
-    \\info(xtxf): ｹ: 19x14 0/0
-    \\info(xtxf): ﾏ: 19x15 256/0
-    \\info(xtxf): V: 19x16 0/0
-    \\info(xtxf): ﾅ: 19x17 0/0
-    \\info(xtxf): ﾄ: 19x18 0/0
-    \\info(xtxf): ｢: 19x19 0/0
+    \\info(xtxf): -: 10x9 0/0
+    \\info(xtxf): ﾘ: 11x0 0/0
+    \\info(xtxf): ｶ: 11x1 0/0
+    \\info(xtxf): ﾘ: 11x2 0/0
+    \\info(xtxf): ｲ: 11x3 0/0
+    \\info(xtxf): ﾒ: 11x4 0/0
+    \\info(xtxf): .: 11x5 0/0
+    \\info(xtxf): ﾀ: 11x6 0/0
+    \\info(xtxf): ｳ: 11x7 0/0
+    \\info(xtxf): ﾈ: 11x8 0/0
+    \\info(xtxf): ﾓ: 11x9 0/0
     \\info(xtxf): Exiting...
     \\
 ;
 
 pub const red =
-    \\info(xtxf): 1: 19x13 258/0
-    \\info(xtxf): 1: 19x14 2/0
-    \\info(xtxf): 1: 19x15 2/0
-    \\info(xtxf): 1: 19x16 2/0
-    \\info(xtxf): 0: 19x17 2/0
-    \\info(xtxf): 1: 19x18 2/0
-    \\info(xtxf): 1: 19x19 2/0
+    \\info(xtxf): 1: 10x9 2/0
+    \\info(xtxf): 1: 11x0 2/0
+    \\info(xtxf): 0: 11x1 2/0
+    \\info(xtxf): 0: 11x2 2/0
+    \\info(xtxf): 0: 11x3 2/0
+    \\info(xtxf): 1: 11x4 2/0
+    \\info(xtxf): 0: 11x5 2/0
+    \\info(xtxf): 0: 11x6 2/0
+    \\info(xtxf): 0: 11x7 2/0
+    \\info(xtxf): 1: 11x8 2/0
+    \\info(xtxf): 0: 11x9 2/0
     \\info(xtxf): Exiting...
     \\
 ;
 
 pub const green =
-    \\info(xtxf): 1: 19x13 259/0
-    \\info(xtxf): 1: 19x14 3/0
-    \\info(xtxf): 1: 19x15 3/0
-    \\info(xtxf): 1: 19x16 3/0
-    \\info(xtxf): 0: 19x17 3/0
-    \\info(xtxf): 1: 19x18 3/0
-    \\info(xtxf): 1: 19x19 3/0
+    \\info(xtxf): 1: 10x9 3/0
+    \\info(xtxf): 1: 11x0 3/0
+    \\info(xtxf): 0: 11x1 3/0
+    \\info(xtxf): 0: 11x2 3/0
+    \\info(xtxf): 0: 11x3 3/0
+    \\info(xtxf): 1: 11x4 3/0
+    \\info(xtxf): 0: 11x5 3/0
+    \\info(xtxf): 0: 11x6 3/0
+    \\info(xtxf): 0: 11x7 3/0
+    \\info(xtxf): 1: 11x8 3/0
+    \\info(xtxf): 0: 11x9 3/0
     \\info(xtxf): Exiting...
     \\
 ;
 
 pub const blue =
-    \\info(xtxf): 1: 19x13 261/0
-    \\info(xtxf): 1: 19x14 5/0
-    \\info(xtxf): 1: 19x15 5/0
-    \\info(xtxf): 1: 19x16 5/0
-    \\info(xtxf): 0: 19x17 5/0
-    \\info(xtxf): 1: 19x18 5/0
-    \\info(xtxf): 1: 19x19 5/0
+    \\info(xtxf): 1: 10x9 5/0
+    \\info(xtxf): 1: 11x0 5/0
+    \\info(xtxf): 0: 11x1 5/0
+    \\info(xtxf): 0: 11x2 5/0
+    \\info(xtxf): 0: 11x3 5/0
+    \\info(xtxf): 1: 11x4 5/0
+    \\info(xtxf): 0: 11x5 5/0
+    \\info(xtxf): 0: 11x6 5/0
+    \\info(xtxf): 0: 11x7 5/0
+    \\info(xtxf): 1: 11x8 5/0
+    \\info(xtxf): 0: 11x9 5/0
     \\info(xtxf): Exiting...
     \\
 ;
 
 pub const yellow =
-    \\info(xtxf): 1: 19x13 260/0
-    \\info(xtxf): 1: 19x14 4/0
-    \\info(xtxf): 1: 19x15 4/0
-    \\info(xtxf): 1: 19x16 4/0
-    \\info(xtxf): 0: 19x17 4/0
-    \\info(xtxf): 1: 19x18 4/0
-    \\info(xtxf): 1: 19x19 4/0
+    \\info(xtxf): 1: 10x9 4/0
+    \\info(xtxf): 1: 11x0 4/0
+    \\info(xtxf): 0: 11x1 4/0
+    \\info(xtxf): 0: 11x2 4/0
+    \\info(xtxf): 0: 11x3 4/0
+    \\info(xtxf): 1: 11x4 4/0
+    \\info(xtxf): 0: 11x5 4/0
+    \\info(xtxf): 0: 11x6 4/0
+    \\info(xtxf): 0: 11x7 4/0
+    \\info(xtxf): 1: 11x8 4/0
+    \\info(xtxf): 0: 11x9 4/0
     \\info(xtxf): Exiting...
     \\
 ;
 
 pub const magenta =
-    \\info(xtxf): 1: 19x13 262/0
-    \\info(xtxf): 1: 19x14 6/0
-    \\info(xtxf): 1: 19x15 6/0
-    \\info(xtxf): 1: 19x16 6/0
-    \\info(xtxf): 0: 19x17 6/0
-    \\info(xtxf): 1: 19x18 6/0
-    \\info(xtxf): 1: 19x19 6/0
+    \\info(xtxf): 1: 10x9 6/0
+    \\info(xtxf): 1: 11x0 6/0
+    \\info(xtxf): 0: 11x1 6/0
+    \\info(xtxf): 0: 11x2 6/0
+    \\info(xtxf): 0: 11x3 6/0
+    \\info(xtxf): 1: 11x4 6/0
+    \\info(xtxf): 0: 11x5 6/0
+    \\info(xtxf): 0: 11x6 6/0
+    \\info(xtxf): 0: 11x7 6/0
+    \\info(xtxf): 1: 11x8 6/0
+    \\info(xtxf): 0: 11x9 6/0
     \\info(xtxf): Exiting...
     \\
 ;
 
 pub const columns =
-    \\info(xtxf): 6: 19x14 0/0
-    \\info(xtxf): 4: 19x15 0/0
-    \\info(xtxf): 3: 19x16 256/0
-    \\info(xtxf): 4: 19x17 256/0
-    \\info(xtxf): 2: 19x18 0/0
-    \\info(xtxf): 3: 19x19 0/0
+    \\info(xtxf): 8: 10x8 0/0
+    \\info(xtxf): 1: 10x9 0/0
+    \\info(xtxf): 7: 11x0 0/0
+    \\info(xtxf): 8: 11x1 0/0
+    \\info(xtxf): 5: 11x2 0/0
+    \\info(xtxf): 2: 11x3 0/0
+    \\info(xtxf): 1: 11x4 0/0
+    \\info(xtxf): 5: 11x5 0/0
+    \\info(xtxf): 0: 11x6 0/0
+    \\info(xtxf): 1: 11x7 0/0
+    \\info(xtxf): 7: 11x8 0/0
+    \\info(xtxf): 7: 11x9 0/0
     \\info(xtxf): Exiting...
     \\
 ;
 
 pub const crypto =
-    \\info(xtxf): 1: 19x11 256/0
-    \\info(xtxf): 1: 19x13 0/0
-    \\info(xtxf): 3: 19x14 256/0
-    \\info(xtxf): E: 19x16 0/0
-    \\info(xtxf): 9: 19x17 0/0
-    \\info(xtxf): 8: 19x19 0/0
+    \\info(xtxf): 8: 9x7 0/0
+    \\info(xtxf): 9: 9x8 0/0
+    \\info(xtxf): 8: 11x1 0/0
+    \\info(xtxf): 3: 11x2 0/0
+    \\info(xtxf): 7: 11x4 0/0
+    \\info(xtxf): 2: 11x5 0/0
+    \\info(xtxf): B: 11x7 0/0
+    \\info(xtxf): 3: 11x8 0/0
     \\info(xtxf): Exiting...
     \\
 ;
 
 pub const grid =
-    \\info(xtxf): 0: 19x9 256/0
-    \\info(xtxf): 1: 19x11 0/0
-    \\info(xtxf): 0: 19x13 0/0
-    \\info(xtxf): 0: 19x15 0/0
-    \\info(xtxf): 0: 19x17 256/0
-    \\info(xtxf): 0: 19x19 0/0
+    \\info(xtxf): 1: 9x5 0/0
+    \\info(xtxf): 0: 9x7 0/0
+    \\info(xtxf): 1: 9x9 0/0
+    \\info(xtxf): 0: 11x1 0/0
+    \\info(xtxf): 0: 11x3 0/0
+    \\info(xtxf): 1: 11x5 0/0
+    \\info(xtxf): 1: 11x7 0/0
+    \\info(xtxf): 1: 11x9 0/0
     \\info(xtxf): Exiting...
     \\
 ;
 
 pub const blocks =
-    \\info(xtxf): 1: 19x13 0/0
-    \\info(xtxf): 2: 19x14 0/0
-    \\info(xtxf): 7: 19x15 0/0
-    \\info(xtxf): 4: 19x16 256/0
-    \\info(xtxf): 5: 19x17 0/0
-    \\info(xtxf): 4: 19x19 0/0
+    \\info(xtxf): 2: 9x8 0/0
+    \\info(xtxf): 3: 9x9 0/0
+    \\info(xtxf): 9: 11x1 0/0
+    \\info(xtxf): 7: 11x2 0/0
+    \\info(xtxf): 5: 11x3 0/0
+    \\info(xtxf): 4: 11x4 0/0
+    \\info(xtxf): 3: 11x5 0/0
+    \\info(xtxf): 2: 11x7 0/0
+    \\info(xtxf): 8: 11x8 0/0
+    \\info(xtxf): 1: 11x9 0/0
     \\info(xtxf): Exiting...
     \\
 ;
 
 pub const rain =
-    \\info(xtxf): ﾄ: 19x14 0/0
-    \\info(xtxf): ｾ: 19x15 0/0
-    \\info(xtxf): ｰ: 19x16 256/0
-    \\info(xtxf): ﾆ: 19x17 0/0
-    \\info(xtxf): #: 19x18 0/0
-    \\info(xtxf): 6: 19x19 0/0
+    \\info(xtxf): ﾊ: 10x8 0/0
+    \\info(xtxf): ｴ: 10x9 0/0
+    \\info(xtxf): ﾓ: 11x0 0/0
+    \\info(xtxf): ﾈ: 11x1 0/0
+    \\info(xtxf): ｳ: 11x2 0/0
+    \\info(xtxf): ﾀ: 11x3 0/0
+    \\info(xtxf): .: 11x4 0/0
+    \\info(xtxf): ﾒ: 11x5 0/0
+    \\info(xtxf): ｲ: 11x6 0/0
+    \\info(xtxf): ﾘ: 11x7 0/0
+    \\info(xtxf): ｶ: 11x8 0/0
+    \\info(xtxf): ﾘ: 11x9 0/0
     \\info(xtxf): Exiting...
     \\
 ;

--- a/test/streams.zig
+++ b/test/streams.zig
@@ -1,0 +1,180 @@
+pub const default =
+    \\info(xtxf): 0: 19x0 0/0
+    \\info(xtxf): 0: 19x1 0/0
+    \\info(xtxf): 0: 19x2 256/0
+    \\info(xtxf): 0: 19x3 256/0
+    \\info(xtxf): 0: 19x4 256/0
+    \\info(xtxf): 1: 19x5 256/0
+    \\info(xtxf): 0: 19x6 256/0
+    \\info(xtxf): 1: 19x7 0/0
+    \\info(xtxf): 0: 19x8 256/0
+    \\info(xtxf): 0: 19x9 0/0
+    \\info(xtxf): 1: 19x10 256/0
+    \\info(xtxf): 0: 19x11 256/0
+    \\info(xtxf): 1: 19x12 0/0
+    \\info(xtxf): 1: 19x13 256/0
+    \\info(xtxf): 1: 19x14 0/0
+    \\info(xtxf): 1: 19x15 0/0
+    \\info(xtxf): 1: 19x16 0/0
+    \\info(xtxf): 0: 19x17 0/0
+    \\info(xtxf): 1: 19x18 0/0
+    \\info(xtxf): 1: 19x19 0/0
+    \\info(xtxf): Exiting...
+    \\
+;
+
+pub const decimal =
+    \\info(xtxf): 9: 19x10 0/0
+    \\info(xtxf): 8: 19x11 0/0
+    \\info(xtxf): 2: 19x12 256/0
+    \\info(xtxf): 2: 19x13 256/0
+    \\info(xtxf): 9: 19x14 256/0
+    \\info(xtxf): 6: 19x15 0/0
+    \\info(xtxf): 6: 19x16 0/0
+    \\info(xtxf): 5: 19x17 256/0
+    \\info(xtxf): 0: 19x18 256/0
+    \\info(xtxf): 0: 19x19 0/0
+    \\info(xtxf): Exiting...
+    \\
+;
+
+pub const hexadecimal =
+    \\info(xtxf): F: 19x12 0/0
+    \\info(xtxf): D: 19x13 256/0
+    \\info(xtxf): 3: 19x14 0/0
+    \\info(xtxf): 7: 19x15 0/0
+    \\info(xtxf): D: 19x16 0/0
+    \\info(xtxf): 4: 19x17 0/0
+    \\info(xtxf): 3: 19x18 0/0
+    \\info(xtxf): 9: 19x19 0/0
+    \\info(xtxf): Exiting...
+    \\
+;
+
+pub const textual =
+    \\info(xtxf): +: 19x12 0/0
+    \\info(xtxf): -: 19x13 0/0
+    \\info(xtxf): ｹ: 19x14 0/0
+    \\info(xtxf): ﾏ: 19x15 256/0
+    \\info(xtxf): V: 19x16 0/0
+    \\info(xtxf): ﾅ: 19x17 0/0
+    \\info(xtxf): ﾄ: 19x18 0/0
+    \\info(xtxf): ｢: 19x19 0/0
+    \\info(xtxf): Exiting...
+    \\
+;
+
+pub const red =
+    \\info(xtxf): 1: 19x13 258/0
+    \\info(xtxf): 1: 19x14 2/0
+    \\info(xtxf): 1: 19x15 2/0
+    \\info(xtxf): 1: 19x16 2/0
+    \\info(xtxf): 0: 19x17 2/0
+    \\info(xtxf): 1: 19x18 2/0
+    \\info(xtxf): 1: 19x19 2/0
+    \\info(xtxf): Exiting...
+    \\
+;
+
+pub const green =
+    \\info(xtxf): 1: 19x13 259/0
+    \\info(xtxf): 1: 19x14 3/0
+    \\info(xtxf): 1: 19x15 3/0
+    \\info(xtxf): 1: 19x16 3/0
+    \\info(xtxf): 0: 19x17 3/0
+    \\info(xtxf): 1: 19x18 3/0
+    \\info(xtxf): 1: 19x19 3/0
+    \\info(xtxf): Exiting...
+    \\
+;
+
+pub const blue =
+    \\info(xtxf): 1: 19x13 261/0
+    \\info(xtxf): 1: 19x14 5/0
+    \\info(xtxf): 1: 19x15 5/0
+    \\info(xtxf): 1: 19x16 5/0
+    \\info(xtxf): 0: 19x17 5/0
+    \\info(xtxf): 1: 19x18 5/0
+    \\info(xtxf): 1: 19x19 5/0
+    \\info(xtxf): Exiting...
+    \\
+;
+
+pub const yellow =
+    \\info(xtxf): 1: 19x13 260/0
+    \\info(xtxf): 1: 19x14 4/0
+    \\info(xtxf): 1: 19x15 4/0
+    \\info(xtxf): 1: 19x16 4/0
+    \\info(xtxf): 0: 19x17 4/0
+    \\info(xtxf): 1: 19x18 4/0
+    \\info(xtxf): 1: 19x19 4/0
+    \\info(xtxf): Exiting...
+    \\
+;
+
+pub const magenta =
+    \\info(xtxf): 1: 19x13 262/0
+    \\info(xtxf): 1: 19x14 6/0
+    \\info(xtxf): 1: 19x15 6/0
+    \\info(xtxf): 1: 19x16 6/0
+    \\info(xtxf): 0: 19x17 6/0
+    \\info(xtxf): 1: 19x18 6/0
+    \\info(xtxf): 1: 19x19 6/0
+    \\info(xtxf): Exiting...
+    \\
+;
+
+pub const columns =
+    \\info(xtxf): 6: 19x14 0/0
+    \\info(xtxf): 4: 19x15 0/0
+    \\info(xtxf): 3: 19x16 256/0
+    \\info(xtxf): 4: 19x17 256/0
+    \\info(xtxf): 2: 19x18 0/0
+    \\info(xtxf): 3: 19x19 0/0
+    \\info(xtxf): Exiting...
+    \\
+;
+
+pub const crypto =
+    \\info(xtxf): 1: 19x11 256/0
+    \\info(xtxf): 1: 19x13 0/0
+    \\info(xtxf): 3: 19x14 256/0
+    \\info(xtxf): E: 19x16 0/0
+    \\info(xtxf): 9: 19x17 0/0
+    \\info(xtxf): 8: 19x19 0/0
+    \\info(xtxf): Exiting...
+    \\
+;
+
+pub const grid =
+    \\info(xtxf): 0: 19x9 256/0
+    \\info(xtxf): 1: 19x11 0/0
+    \\info(xtxf): 0: 19x13 0/0
+    \\info(xtxf): 0: 19x15 0/0
+    \\info(xtxf): 0: 19x17 256/0
+    \\info(xtxf): 0: 19x19 0/0
+    \\info(xtxf): Exiting...
+    \\
+;
+
+pub const blocks =
+    \\info(xtxf): 1: 19x13 0/0
+    \\info(xtxf): 2: 19x14 0/0
+    \\info(xtxf): 7: 19x15 0/0
+    \\info(xtxf): 4: 19x16 256/0
+    \\info(xtxf): 5: 19x17 0/0
+    \\info(xtxf): 4: 19x19 0/0
+    \\info(xtxf): Exiting...
+    \\
+;
+
+pub const rain =
+    \\info(xtxf): ﾄ: 19x14 0/0
+    \\info(xtxf): ｾ: 19x15 0/0
+    \\info(xtxf): ｰ: 19x16 256/0
+    \\info(xtxf): ﾆ: 19x17 0/0
+    \\info(xtxf): #: 19x18 0/0
+    \\info(xtxf): 6: 19x19 0/0
+    \\info(xtxf): Exiting...
+    \\
+;


### PR DESCRIPTION
Adds dimmed symbols and moves `bold` behind the optional flag.